### PR TITLE
ARC: ELF header tag updated to reflect the new kernel syscall ABI

### DIFF
--- a/ChangeLog.ARC
+++ b/ChangeLog.ARC
@@ -1,3 +1,8 @@
+2013-03-28  Vineet Gupta <vgupta@synopsys.com>
+
+	* include/elf/arc.h: E_ARC_OSABI_CURRENT bumped to v3 due to newer
+	kernel syscall ABI (3.9 kernel + uClibc 0.9.34)
+
 2013-02-25  Simon Cook  <simon.cook@embecosm.com>
 
 	* Makefile.def: Brought in from updated gcc.

--- a/include/elf/arc.h
+++ b/include/elf/arc.h
@@ -121,6 +121,7 @@ END_RELOC_NUMBERS (R_ARC_max)
 /* ARC Linux specific ABIs */
 #define E_ARC_OSABI_ORIG	0x00000000   /* MUST be zero for back-compat */
 #define E_ARC_OSABI_V2		0x00000200
-#define E_ARC_OSABI_CURRENT	E_ARC_OSABI_V2
+#define E_ARC_OSABI_V3		0x00000300
+#define E_ARC_OSABI_CURRENT	E_ARC_OSABI_V3
 
 #endif /* _ELF_ARC_H */


### PR DESCRIPTION
2013-03-28  Vineet Gupta vgupta@synopsys.com

```
* include/elf/arc.h: E_ARC_OSABI_CURRENT bumped to v3 due to
* newer
kernel syscall ABI (3.9 kernel + uClibc 0.9.34)
```

Signed-off-by: Vineet Gupta vgupta@synopsys.com
