### PR TITLE
Add EM as a valid processor option.

### DIFF
--- a/bfd/cpu-arc.c
+++ b/bfd/cpu-arc.c
@@ -51,7 +51,8 @@ static const bfd_arch_info_type arch_info_struct[] =
   ARC ( bfd_mach_arc_arc600, "A6"    , FALSE, &arch_info_struct[4] ),
   ARC ( bfd_mach_arc_arc601, "ARC601", FALSE, &arch_info_struct[5] ),
   ARC ( bfd_mach_arc_arc700, "ARC700", FALSE, &arch_info_struct[6] ),
-  ARC ( bfd_mach_arc_arc700, "A7",     FALSE, NULL),
+  ARC ( bfd_mach_arc_arc700, "A7",     FALSE, &arch_info_struct[7] ),
+  ARC ( bfd_mach_arc_arcv2,  "EM",     FALSE, NULL),
 };
 
 const bfd_arch_info_type bfd_arc_arch =


### PR DESCRIPTION
Fixes an issue coming from merging the EM binutils with public repository. This is required to get the EM toolchain compiled.
