### PR TITLE
Clean up code

### DIFF
--- a/bfd/ChangeLog.ARC
+++ b/bfd/ChangeLog.ARC
@@ -1,5 +1,10 @@
 2013-01-30 Claudiu Zissulescu <claziss@synopsys.com>
 
+	* elf32-arc.c : Clean up. Rezolve crashing of the linker when
+	two different architecture binary are linked together.
+
+2013-01-30 Claudiu Zissulescu <claziss@synopsys.com>
+
 	* cpu-arc.c (arc_info_struct): Add EM as valid processor type.
 
 2013-04-03  Simon Cook  <simon.cook@embecosm.com>

--- a/bfd/elf32-arc.c
+++ b/bfd/elf32-arc.c
@@ -641,18 +641,11 @@ of opposite endian-ness"),
     }
   else
     {
-      /*czi
-      if((mach_ibfd==EM_ARC && mach_obfd==EM_ARCOMPACT) ||
-	 (mach_ibfd==EM_ARCOMPACT && mach_obfd==EM_ARC))
-      */
       if(mach_ibfd != mach_obfd)
 	{
-	  _bfd_error_handler (_("\ERROR: Attempting to link an %s binary(%B) \
-with a binary incompatible %s binary(%s)"),
-			      (mach_ibfd == EM_ARC) ? "A4" : "ARCompact",
-			      ibfd,
-			      (mach_obfd == EM_ARC) ? "A4" : "ARCompact",
-			      bfd_get_filename (obfd));
+	  _bfd_error_handler (_("ERROR: Attempting to link %B \
+with a binary %s of different architecture"),
+			      ibfd, bfd_get_filename (obfd));
 	  return FALSE;
 	}
     }


### PR DESCRIPTION
Resolve coredump of the linker when linking arcv1 and arcv2 objects together. 
