### PR TITLE
Relocation enhancement for ARCv2

### DIFF
--- a/bfd/ChangeLog.ARC
+++ b/bfd/ChangeLog.ARC
@@ -1,3 +1,8 @@
+2013-07-31 Claudiu Zissulescu <claziss@synopsys.com>
+
+	* elf32-arc.c: Add relocation support for ld_s r1,[gp,s11]
+	and st_s r0,[gp,s11] instructions.
+
 2013-06-28 Vineet Gupta <vgupta@synopsys.com>
 
 	* elf32-arc.c: Replaced EM_ARCOMPACT2 with EM_ARCV2

--- a/bfd/elf32-arc.c
+++ b/bfd/elf32-arc.c
@@ -1352,7 +1352,16 @@ arc_plugin_one_reloc (unsigned long insn, Elf_Internal_Rela *rel,
     value >>= 1;
   case R_ARC_SDA_LDST:
     value &= 0x1ff;
-    insn |= ( ((value & 0xff) << 16)  | ((value >> 8) << 15));
+    if ((insn &  0xF8180000) == 0x50100000)
+      {
+	/* insert ARCv2 S11 value into ST_S RO,[GP,S11]. */
+	insn |= (value & 0x1F8) << 18;
+	insn |= (value & 0x07) << 16;
+      }
+    else
+      {
+	insn |= ( ((value & 0xff) << 16)  | ((value >> 8) << 15));
+      }
     break;
 
   case R_ARC_SDA16_LD:
@@ -1367,7 +1376,16 @@ arc_plugin_one_reloc (unsigned long insn, Elf_Internal_Rela *rel,
 
   case R_ARC_SDA16_LD2:
     /* FIXME: The 16-bit insns shd not come in as higher bits of a 32-bit word */
-    insn |= ((value >> 2) & 0x1ff) <<16;
+    if ((insn & 0xF8180000) == 0x50000000)
+      {
+	/* insert ARCv2 S11 value. */
+	insn |= ((value >> 2) & 0x1F8) << 18;
+	insn |= ((value >> 2) & 0x07) << 16;
+      }
+    else
+      {
+	insn |= ((value >> 2) & 0x1ff) <<16;
+      }
     break;
     
     

--- a/opcodes/ChangeLog.ARC
+++ b/opcodes/ChangeLog.ARC
@@ -1,3 +1,9 @@
+2013-07-31 Claudiu Zissulescu <claziss@synopsys.com>
+
+	* arc-em.h: Add relocation support for ld_s r1,[gp,s11] and
+	st_s r0,[gp,s11] instructions.
+	* arc-opc-old.c: Likewise.
+
 2013-07-24  Claudiu Zissulescu <claziss@synopsys.com>
 
         * arc-em.h: Add LLOCK mnemonic to EM

--- a/opcodes/arc-em.h
+++ b/opcodes/arc-em.h
@@ -794,7 +794,9 @@
 { (unsigned char *) "ldi%Q 0,[%L]",                          0xFFFFFFFF, 0x26267F80, ARC_MACH_ARCV2, 0, 0, 0, 0},
 /*ST_S */
 /* st_s    R0,[GP,Ss11] 	0101 0SSS SSS1 0sss  */
+{ (unsigned char *) "st_s %4,[%5,%[L]",                         0xF818, 0x5010, ARC_MACH_ARCV2, 0, 0, 0, 0},
 { (unsigned char *) "st_s %4,[%5,%ç]",                       0xF818, 0x5010, ARC_MACH_ARCV2, 0, 0, 0, 0},
+{ (unsigned char *) "st_s %4,[%5]",                             0xF818, 0x5010, ARC_MACH_ARCV2, 0, 0, 0, 0},
 /*ST */
 { (unsigned char *) "st%z%.w%.D %Ñ,[%g]%0",                  0xF8FF8001, 0x18000001, ARC_MACH_ARCV2, 0, 0, 0, 0},
 { (unsigned char *) "st%z%.w%.D %Ñ,[%g,%o]%0",               0xF8000001, 0x18000001, ARC_MACH_ARCV2, 0, 0, 0, 0},
@@ -819,7 +821,10 @@
 /* ld_s<.aa>    a,[b,c] 	0100 1bbb ccc0 0aaa  */
 { (unsigned char *) "ld_s.as %a,[%b,%c]",                    0xF818, 0x4800, ARC_MACH_ARCV2, 0, 0, 0, 0},
 /* ld_s    R1,[GP,Ss11] 	0101 0SSS SSS0 0sss  */
+{ (unsigned char *) "ld_s %Å,[%5,%[L]",                         0xF818, 0x5000, ARC_MACH_ARCV2, 0, 0, 0, 0},
 { (unsigned char *) "ld_s %Å,[%5,%ç]",                       0xF818, 0x5000, ARC_MACH_ARCV2, 0, 0, 0, 0},
+{ (unsigned char *) "ld_s %Å,[%5]",                             0xF818, 0x5000, ARC_MACH_ARCV2, 0, 0, 0, 0},
+
 /*J missing J [BLINK]*/
 /* j    c               	0010 0RRR 0010 0000 RRRR CCCC CCRR RRRR  */
 { (unsigned char *) "j [%C]",                                0xFFFFF03F, 0x20200000, ARC_MACH_ARCV2, 0, 0, 0, 0},

--- a/opcodes/arc-opc-old.c
+++ b/opcodes/arc-opc-old.c
@@ -5249,6 +5249,10 @@ ac_get_load_sdasym_insn_type (arc_insn insn, int compact_insn_16)
 	  load_type = 12;
 	  break;
 	}
+     if ((insn & 0xF818) == 0x5000)
+	{
+	  load_type = 10;
+	}
     }
   else
     {
@@ -5296,34 +5300,44 @@ ac_get_load_sdasym_insn_type (arc_insn insn, int compact_insn_16)
 */
 int
 ac_get_store_sdasym_insn_type (arc_insn insn,
-			       int compact_insn_16 ATTRIBUTE_UNUSED)
+			       int compact_insn_16)
 {
   int store_type = -1;
 
-  /* st/stw/stb */
-  switch (insn & 0xf8000007)
+  /* st_s r0,[gp,s11] */
+  if (compact_insn_16)
     {
-      /* st */
-    case 0x18000000:
-      if (((insn>>3) & 3) == 3)
-	store_type = 0;
-      else
-	store_type = 1;
-      break;
+      if ((insn &  0xF818) == 0x5010)
+	{
+	  store_type = 0;
+	}
+    }
+  else
+    {
+      /* st/stw/stb */
+      switch (insn & 0xf8000007)
+	{
+	  /* st */
+	case 0x18000000:
+	  if (((insn>>3) & 3) == 3)
+	    store_type = 0;
+	  else
+	    store_type = 1;
+	  break;
 
-      /* stw */
-    case 0x18000004:
-      if (((insn>>3) & 3) == 3)
-	store_type = 2;
-      else
-	store_type = 1;
-      break;
+	  /* stw */
+	case 0x18000004:
+	  if (((insn>>3) & 3) == 3)
+	    store_type = 2;
+	  else
+	    store_type = 1;
+	  break;
 
-      /* stb */
-    case 0x18000002:
-      store_type = 1;
-      break;
-
+	  /* stb */
+	case 0x18000002:
+	  store_type = 1;
+	  break;
+	}
     }
 
   return store_type;


### PR DESCRIPTION
 Add relocation support for ld_s r1,[gp,s11] and st_s r0,[gp,s11] instructions.
