### PR TITLE
ARC: Write to _addrWriteBack field in dsmArcOneInst

### DIFF
--- a/opcodes/ChangeLog.ARC
+++ b/opcodes/ChangeLog.ARC
@@ -1,3 +1,9 @@
+2013-08-23 Anton Kolesov <akolesov@synopsys.com>
+
+	* arcompact-dis.c, arc-dis-old.c (dsmOneArcInst): Field _addrWriteBack was
+	not written to result structure. This field is required by GDB to properly
+	recognize prologue in functions without full debug information.
+
 2013-08-05 Claudiu Zissulescu <claziss@synopsys.com>
 
 	* arc-em.h: Modify enter_s and leave_s mnemonics by adding

--- a/opcodes/arc-dis-old.c
+++ b/opcodes/arc-dis-old.c
@@ -1137,6 +1137,7 @@ dsmOneArcInst (bfd_vma addr, struct arcDisState * state)
     }
 
   state->_cond = cond;
+  state->_addrWriteBack = addrWriteBack;
   return state->instructionLen = offset;
 }
 

--- a/opcodes/arcompact-dis.c
+++ b/opcodes/arcompact-dis.c
@@ -4399,6 +4399,7 @@ dsmOneArcInst (bfd_vma addr, struct arcDisState *state, disassemble_info * info)
   }
 
   state->_cond = cond;
+  state->_addrWriteBack = addrWriteBack;
   return state->instructionLen = offset;
 }
 


### PR DESCRIPTION
Field _addrWriteBack was not written to result structure. This field is required by GDB to properly recognize prologue in functions without full debug information.
