### PR TITLE
Do not build testglue if it is not required

### DIFF
--- a/binutils/testsuite/ChangeLog
+++ b/binutils/testsuite/ChangeLog
@@ -1,3 +1,7 @@
+2013-09-10  Anton Kolesov  <akolesov@synopsys.com>
+
+	* binutils-all/objcopy.exp: Build testglue only if required.
+
 2013-02-14  Maciej W. Rozycki  <macro@codesourcery.com>
 
 	* binutils-all/mips/mixed-mips16.s: Add missing stack adjustment.

--- a/binutils/testsuite/binutils-all/objcopy.exp
+++ b/binutils/testsuite/binutils-all/objcopy.exp
@@ -561,7 +561,12 @@ proc copy_setup { } {
     global test_prog
     global host_triplet
     
-    set res [build_wrapper testglue.o]
+    if { [target_info needs_status_wrapper] != "" && \
+         [target_info needs_status_wrapper] != "0" } {
+        set res [build_wrapper testglue.o]
+    } else {
+        set res ""
+    }
     set flags { debug }
     
     if { [istarget *-*-uclinux*] && ![istarget tic6x-*-*] } {


### PR DESCRIPTION
ARC newlib doesn't have function _exit, however Dejagnu testglue is intended
to wrap around it. Thus function _exit() gets created even though it is
never called. When performing execution tests Dejagnu sets breakpoints at
"exit" functions: abort() and _exit(), if it couldn't set at _exit() then at
exit(). That latter case should be applied to ARC, but instead we get
breakpoint at function created by testglue which is never called.

This patch adds a conditional clause that checks whether user explicitly
requested to not use testglue (aka status wrapper). This is the case with
ARC: we don't need testglue, so we disable it. GCC testsuite already has
such condition clauses using `board_info needs_status_wrapper` and this
patch uses the very same variable.
