### PR TITLE
ARC: Parse NOTE section in core dump files

### DIFF
--- a/bfd/ChangeLog.ARC
+++ b/bfd/ChangeLog.ARC
@@ -1,3 +1,9 @@
+2013-09-12 Anton Kolesov <akolesov@synopsys.com>
+
+	* elf32-arc.c (elf32_arc_grok_prstatus): New function to parse NOTE
+	section in core dump files. GDB requires this to work properly with core
+	dumps.
+
 2013-09-11 Simon Cook  <simon.cook@embecosm.com>
 
 	* elf32-arc.c (elf_backend_default_execstack): Set default stack state


### PR DESCRIPTION
New function elf32_arc_grok_parse to parse NOTE section in core dump files. GDB requires this to work properly with core dumps.

GDB expects general purpose registers to be in section .reg. However Linux kernel doesn't create this section and instead writes registers to NOTE section. It is up to the binutils to create a pseudosection .reg from the contents of NOTE. This patch adds this functionality to the ARC. Also BFD will read from NOTE process id and signal number that caused failure. This function relies on offsets inside elf_prstatus structure in Linux.
