### PR TITLE
ARC: Disable --gc-sections

### DIFF
--- a/bfd/ChangeLog.ARC
+++ b/bfd/ChangeLog.ARC
@@ -1,3 +1,8 @@
+2013-11-06  Anton Kolesov  <anton.kolesov@synopsys.com>
+
+	* elf32-arc.c (elf_backend_can_gc_sections): Set to 0, because
+	--gc-sections causes known troubles for ARC.
+
 2013-10-31  Vineet Gupta <vgupta@synopsys.com>
 
 	*  elf32-arc.c (elf_arc_reloc_type): Add new relocations to syncup

--- a/bfd/elf32-arc.c
+++ b/bfd/elf32-arc.c
@@ -3395,7 +3395,7 @@ elf32_arc_grok_prstatus (bfd *abfd, Elf_Internal_Note *note)
 #define elf_backend_grok_prstatus elf32_arc_grok_prstatus
 
 #define elf_backend_gc_sweep_hook	elf32_arc_gc_sweep_hook
-#define elf_backend_can_gc_sections    1
+#define elf_backend_can_gc_sections    0
 #define elf_backend_want_got_plt 1
 #define elf_backend_plt_readonly 1
 #define elf_backend_want_plt_sym 0


### PR DESCRIPTION
It is a known problem (see STAR 9000656506) that ld option --gc-sections
cause failed assertions for ARC. Until the root cause will be resolved,
disable --gc-sections.

Signed-off-by: Anton Kolesov anton.kolesov@synopsys.com
